### PR TITLE
Vehicles options endpoints

### DIFF
--- a/app/controllers/api/v1/vehicles_options_controller.rb
+++ b/app/controllers/api/v1/vehicles_options_controller.rb
@@ -6,9 +6,18 @@ class Api::V1::VehiclesOptionsController < ApplicationController
     json_response(@vehicle_option, :created, :vehicle)
   end
 
+  def destroy
+    @vehicle_option.destroy
+    head :no_content
+  end
+
   private
 
   def vehicle_option_params
     params.permit(:id, :vehicle_id, :option_id)
+  end
+
+  def set_vehicle_option
+    @vehicle_option = VehiclesOption.find(params[:id])
   end
 end

--- a/app/controllers/api/v1/vehicles_options_controller.rb
+++ b/app/controllers/api/v1/vehicles_options_controller.rb
@@ -1,0 +1,14 @@
+class Api::V1::VehiclesOptionsController < ApplicationController
+  before_action :set_vehicle_option, only: :destroy
+
+  def create
+    @vehicle_option = VehiclesOption.create!(vehicle_option_params)
+    json_response(@vehicle_option, :created, :vehicle)
+  end
+
+  private
+
+  def vehicle_option_params
+    params.permit(:id, :vehicle_id, :option_id)
+  end
+end

--- a/app/models/option.rb
+++ b/app/models/option.rb
@@ -1,5 +1,5 @@
 class Option < ApplicationRecord
   validates_presence_of :name
-  has_many :vehicles_options
+  has_many :vehicles_options, dependent: :destroy
   has_many :vehicles, through: :vehicles_options
 end

--- a/app/models/vehicle.rb
+++ b/app/models/vehicle.rb
@@ -1,5 +1,5 @@
 class Vehicle < ApplicationRecord
   validates_presence_of :make, :model
-  has_many :vehicles_options
+  has_many :vehicles_options, dependent: :destroy
   has_many :options, through: :vehicles_options
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,6 +3,7 @@ Rails.application.routes.draw do
     namespace :v1 do
       resources :vehicles
       resources :options
+      resources :vehicles_options, only: [:create, :destroy]
     end
   end
 end

--- a/spec/factories/vehicles_options.rb
+++ b/spec/factories/vehicles_options.rb
@@ -1,5 +1,5 @@
 FactoryBot.define do
-  factory :vehicles_options do
+  factory :vehicles_option do
     option_id nil
     vehicle_id nil
   end

--- a/spec/requests/vehicles_options/delete_vehicles_options_spec.rb
+++ b/spec/requests/vehicles_options/delete_vehicles_options_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe 'Vehicles Options DELETE API', type: :request do
     before { delete "/api/v1/vehicles_options/#{vehicle_option_id}" }
 
     it 'returns a 204 status code' do
-      expect(response).toi have_http_status(204)
+      expect(response).to have_http_status(204)
     end
   end
 end

--- a/spec/requests/vehicles_options/delete_vehicles_options_spec.rb
+++ b/spec/requests/vehicles_options/delete_vehicles_options_spec.rb
@@ -1,0 +1,22 @@
+require 'rails_helper'
+
+RSpec.describe 'Vehicles Options DELETE API', type: :request do
+  let!(:vehicle) {create(:vehicle)}
+  let!(:option) {create(:option)}
+
+  let(:vehicle_id) {vehicle.id}
+  let(:option_id) {option.id}
+
+  let(:vehicle_option) {create(:vehicles_option,
+                                  vehicle_id: vehicle_id,
+                                  option_id: option_id)}
+  let(:vehicle_option_id) {vehicle_option.id}
+
+  describe 'Delete /api/v1/vehicles_options/#{vehicle_option_id}' do
+    before { delete "/api/v1/vehicles_options/#{vehicle_option_id}" }
+
+    it 'returns a 204 status code' do
+      expect(response).toi have_http_status(204)
+    end
+  end
+end

--- a/spec/requests/vehicles_options/post_vehicles_options_spec.rb
+++ b/spec/requests/vehicles_options/post_vehicles_options_spec.rb
@@ -1,0 +1,41 @@
+require 'rails_helper'
+
+RSpec.describe 'Vehicles Options POST API', type: :request do
+  let!(:vehicle) {create(:vehicle)}
+  let!(:option) {create(:option)}
+
+  let(:vehicle_id) {vehicle.id}
+  let(:option_id) {option.id}
+
+  describe "POST /api/v1/vehicles_options" do
+    let(:valid_vehicle_option_attributes) { {
+      vehicle_id: vehicle_id,
+      option_id: option_id
+    } }
+
+    context 'when the record is valid' do
+      before { post '/api/v1/vehicles_options', params: valid_vehicle_option_attributes}
+
+      it "creates an option for a vehicle" do
+        expect(json['vehicle_id']).to eq(vehicle_id)
+        expect(json['option_id']).to eq(option_id)
+      end
+
+      it 'returns a status code 201' do
+        expect(response).to have_http_status(201)
+      end
+    end
+
+    context 'when the record is invalid' do
+      before { post '/api/v1/vehicles_options', params: { vehicle_id: 0, option_id: 0} }
+
+      it "returns status code 422" do
+        expect(response).to have_http_status(422)
+      end
+
+      it "returns an invalid record message" do
+        expect(response.body).to match(/Validation failed:/)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Association endpoints PR.

I created specs for testing the creation and deletion of vehicles_options aka associations between vehicles and options. 

Added dependent: :destroy option to the has_many relationship so that I can ensure that records are deleted correctly and everywhere. 

I created a VehiclesOptionsController for the delete and create action, followed pattern in the other controllers. 

Also small thing, but I modified the vehicles_option factory to make it usable. 